### PR TITLE
Input option for overriding calculated sunrise/sunset values

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This node calculates the position of the sun at a given location.  It is configu
 
 This node can optionally receive a time via an input message containing **msg.time** conforming to Javascript Date object, otherwise it will use the current time.
 
+Also there is an option to overide the calculated sunset/sunrise values via input containing **msg.sunriseoffset** or **msg.sunsetoffset**.
+
 This node emits a <b>msg.payload</b> with the following properties:
 * <b>startTime</b>: time of day that constitutes the start of daylight hours (inclusive of offset)
 * <b>endTime</b>: time of day that constitutes the end of daylight hours (inclusive of offset)

--- a/sunpos/locales/en-US/sunpos.html
+++ b/sunpos/locales/en-US/sunpos.html
@@ -1,10 +1,20 @@
 <script type="text/x-red" data-help-name="sunpos">
-    <p>Test!! Uses the suncalc module to calculate the current position of the sun at a given location.</p>
+    <p>Uses the suncalc module to calculate the current position of the sun at a given location.</p>
 
     <h3>Inputs</h3>
       <dl class="message-properties">
         <dt class="optional">time<span class="property-type">Date</span></dt>
         <dd>time to compute sun position</dd>
+      </dl>
+
+      <dl class="message-properties">
+        <dt class="optional">sunriseoffset<span class="property-type">Number</span></dt>
+        <dd>Override calculated sunrise with minutes</dd>
+      </dl>
+      
+      <dl class="message-properties">
+        <dt class="optional">sunsetoffset<span class="property-type">Number</span></dt>
+        <dd>Override calculated sunset with minutes</dd>
       </dl>
 
     <h3>Outputs</h3>

--- a/sunpos/sunpos.js
+++ b/sunpos/sunpos.js
@@ -36,7 +36,10 @@ module.exports = function(RED) {
     this.on("input", function(msg) {
       var now =
         typeof msg.time != "undefined" ? new Date(msg.time) : new Date();
-
+      var mySunriseOffset =
+        typeof msg.sunriseoffset != "undefined" ? parseInt(msg.sunriseoffset) : 0;
+      var mySunsetOffset =
+        typeof msg.sunsetoffset != "undefined" ? parseInt(msg.sunsetoffset) : 0;
       var sunPosition = SunCalc.getPosition(now, location.lat, location.lon);
       var sunTimes = SunCalc.getTimes(now, location.lat, location.lon);
       var altitudeDegrees = 180 / Math.PI * sunPosition.altitude;
@@ -44,10 +47,10 @@ module.exports = function(RED) {
 
       var nowMillis = now.getTime();
       var startMillis =
-        sunTimes[stConfig.start].getTime() + stConfig.startOffset * 60000;
+        sunTimes[stConfig.start].getTime() + (stConfig.startOffset + mySunriseOffset) * 60000;
       var endMillis =
-        sunTimes[stConfig.end].getTime() + stConfig.endOffset * 60000;
-
+        sunTimes[stConfig.end].getTime() + (stConfig.endOffset + mySunsetOffset) * 60000;
+      
       var sunInSky = nowMillis > startMillis && nowMillis < endMillis;
       if (sunInSky) {
         node.status({


### PR DESCRIPTION
Hi,

I'm using your node as an input for the node-red-contrib-blindcontroller.
Blinds are opened with sunrise & closed with sunset. There are several situations where it could be useful to override these values e.g. open the blinds later at the weekend. So you've got the option to set theses values dynamically through a e.g. flow.context.

